### PR TITLE
Add 'is_original' argument to Novel __init__

### DIFF
--- a/pixivapi/models.py
+++ b/pixivapi/models.py
@@ -352,6 +352,7 @@ class Novel:
         is_muted,
         is_mypixiv_only,
         is_x_restricted,
+        is_original,
         page_count,
         restrict,
         series,


### PR DESCRIPTION
Fixes "TypeError: __init__() got an unexpected keyword argument 'is_original'"